### PR TITLE
Identify Output Artifacts by name, not order

### DIFF
--- a/src/main/java/com/amazonaws/codepipeline/jenkinsplugin/OutputArtifact.java
+++ b/src/main/java/com/amazonaws/codepipeline/jenkinsplugin/OutputArtifact.java
@@ -21,12 +21,19 @@ public final class OutputArtifact implements Serializable {
 
     private final String location;
 
-    public OutputArtifact(final String location) {
+    private final String artifactName;
+
+    public OutputArtifact(final String location, final String artifactName) {
         this.location = location;
+        this.artifactName = artifactName;
     }
 
     public String getLocation() {
         return location;
+    }
+
+    public String getArtifactName() {
+        return artifactName;
     }
 
 }

--- a/src/main/resources/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelinePublisher/config.jelly
+++ b/src/main/resources/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelinePublisher/config.jelly
@@ -5,11 +5,15 @@
   <f:repeatable var="outputLocations" items="${instance.outputArtifacts}" noAddButton="false" minimum="0">
   <table width="100%">
       <f:description>
-          If these locations are left blank the plugin will upload the whole workspace to AWS CodePipeline, if no
-          locations are added, then only the result will be published back to AWS CodePipeline.
+          If a location is left blank the plugin will upload the whole workspace to AWS CodePipeline. Locations
+          will only be published to AWS if there is a corresponding artifact name defined in the output
+          artifact list.
       </f:description>
       <f:entry title="Location">
           <f:textbox name="Location.location" value="${outputLocations.location}" />
+      </f:entry>
+      <f:entry title="Artifact Name">
+          <f:textbox name="ArtifactName.artifactName" value="${outputLocations.artifactName}" />
       </f:entry>
       <f:entry>
           <div align="right">


### PR DESCRIPTION
OutputArtifact now has an artifact name set in the UI that is used to upload output output artifacts based on the artifact name instead of the order of artifact elements.

This is a WIP:

 - Testing should be added
 - The deprecated OutputTuple does not allow for an additional field and would need to be officially removed

***Excerpt from my current case with AWS Support***

> In all cases, the definition of input and output artifacts are defined as a list. When working with these definitions in the UI or with CloudFormation, these elements are also identified by a name. In Jenkins, however, the output artifacts are identified solely by the list element order. In most cases this is okay – different stages and actions within a CodePipeline identify the artifacts they’re working with by the name so the order of their definition shouldn't matter. But this difference between list index, and element name identification becomes an issue when the list order is inconsistent, or is not respected by their definitions.
> 
> In CloudFormation we specify the input/output artifacts like so:
> ```
> "OutputArtifacts": [
>   { "Name": "keymetric-gateway" },
>   { "Name": "processor" },
>   { "Name": "log" }
> ]
> ```
> When we generate the CodePipleine with the CloudFormation template, the following is the result (in a different order than defined):
> ```
> Output artifact #1: log
> Output artifact #2: keymetric-gateway
> Output artifact #3: processor
> ```
> 
> We would expect that the artifact #’s would correspond with the element index when we define them but they don’t. Again, this would normally be okay, except for the fact that the Jenkins plugin identifies its output artifacts strictly by the artifact #. This is causing Jenkins put the “keymetric-gateway” artifact in the “log” location (the processor in log and so on).