### PR TITLE
Add support for new region Ohio us-east-2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.11.24</version>
+      <version>1.11.44</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/src/main/java/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM.java
+++ b/src/main/java/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM.java
@@ -59,7 +59,8 @@ public class AWSCodePipelineSCM extends hudson.scm.SCM {
     public static final Regions[] AVAILABLE_REGIONS = {
         Regions.EU_WEST_1,
         Regions.US_EAST_1,
-        Regions.US_WEST_2
+        Regions.US_WEST_2,
+        Regions.US_EAST_1
     };
 
     public static final CategoryType[] ACTION_TYPE = {


### PR DESCRIPTION
Amazon released new region us-east-1 and CodePipeline is supported over there.
So a quick update of the AVAILABLE_REGIONS list and the sdk version should definitely help.
