### PR TITLE
[maven-release-plugin] prepare release aws-codepipeline-0.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </parent>
 
   <artifactId>aws-codepipeline</artifactId>
-  <version>0.32-SNAPSHOT</version>
+  <version>0.32</version>
   <packaging>hpi</packaging>
   <groupId>com.amazonaws</groupId>
   <name>AWS CodePipeline Plugin</name>
@@ -39,7 +39,7 @@
     <url>https://github.com/jenkinsci/aws-codepipeline-plugin</url>
     <connection>scm:git:ssh://github.com/jenkinsci/aws-codepipeline-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/aws-codepipeline-plugin.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>aws-codepipeline-0.32</tag>
   </scm>
 
   <repositories>


### PR DESCRIPTION
Commit message is messed up because of failed release. Send a pr to fix it.