### PR TITLE
JENKINS-46360 - Allow builds to publish in parallel

### DIFF
--- a/src/main/java/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelinePublisher.java
+++ b/src/main/java/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelinePublisher.java
@@ -211,7 +211,7 @@ public class AWSCodePipelinePublisher extends Notifier {
     }
 
     public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.STEP;
+        return BuildStepMonitor.NONE;
     }
 
     public OutputArtifact[] getOutputArtifacts() {


### PR DESCRIPTION
As per [JENKINS-46360](https://issues.jenkins-ci.org/browse/JENKINS-46360)