### PR TITLE
Improve artifact upload error handling

### DIFF
--- a/src/main/java/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelinePublisher.java
+++ b/src/main/java/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelinePublisher.java
@@ -170,6 +170,10 @@ public class AWSCodePipelinePublisher extends Notifier {
             LoggingHelper.log(listener, ex.getMessage());
             LoggingHelper.log(listener, ex);
             awsStatus = false;
+        } catch (final Throwable ex) {
+            error = "Failed to upload output artifact(s): " + ex.getMessage();
+            awsStatus = false;
+            throw ex;
         } finally {
             PublisherTools.putJobResult(
                     awsStatus,


### PR DESCRIPTION
*Issue #, if available:* #40 

*Description of changes:*

A customer reported on issue #40 that if OutOfMemoryError is thrown
during artifact upload, the upload fails but the action execution is
still marked as succeeded. This change fixes that issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
