### PR TITLE
Use textbox for region selection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <aws-sdk-version>1.12.416</aws-sdk-version>
+    <aws-sdk-version>1.12.573</aws-sdk-version>
   </properties>
 
   <dependencies>

--- a/src/main/java/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM.java
+++ b/src/main/java/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM.java
@@ -30,7 +30,6 @@ import org.kohsuke.stapler.StaplerRequest;
 
 import com.amazonaws.codepipeline.jenkinsplugin.CodePipelineStateModel.CategoryType;
 import com.amazonaws.codepipeline.jenkinsplugin.CodePipelineStateModel.CompressionType;
-import com.amazonaws.regions.Regions;
 import com.amazonaws.services.codepipeline.AWSCodePipeline;
 import com.amazonaws.services.codepipeline.model.AcknowledgeJobRequest;
 import com.amazonaws.services.codepipeline.model.AcknowledgeJobResult;
@@ -62,36 +61,6 @@ import hudson.util.Secret;
 import net.sf.json.JSONObject;
 
 public class AWSCodePipelineSCM extends hudson.scm.SCM {
-
-    public static Regions[] available_regions() {
-        return new Regions[] {
-            Regions.US_EAST_1,
-            Regions.US_EAST_2,
-            Regions.US_GOV_EAST_1,
-            Regions.US_WEST_1,
-            Regions.US_WEST_2,
-            Regions.AF_SOUTH_1,
-            Regions.AP_EAST_1,
-            Regions.AP_SOUTH_1,
-            Regions.AP_NORTHEAST_2,
-            Regions.AP_SOUTHEAST_1,
-            Regions.AP_SOUTHEAST_2,
-            Regions.AP_NORTHEAST_1,
-            Regions.CA_CENTRAL_1,
-            Regions.EU_CENTRAL_1,
-            Regions.EU_CENTRAL_2,
-            Regions.EU_WEST_1,
-            Regions.EU_WEST_2,
-            Regions.EU_SOUTH_1,
-            Regions.EU_WEST_3,
-            Regions.EU_NORTH_1,
-            Regions.ME_SOUTH_1,
-            Regions.SA_EAST_1,
-            Regions.GovCloud,
-            Regions.CN_NORTH_1,
-            Regions.CN_NORTHWEST_1
-        };
-    }
 
     public static CategoryType[] action_type() {
         return new CategoryType[] {
@@ -417,14 +386,24 @@ public class AWSCodePipelineSCM extends hudson.scm.SCM {
             return true;
         }
 
-        public ListBoxModel doFillRegionItems() {
-            final ListBoxModel items = new ListBoxModel();
-
-            for (final Regions region : available_regions()) {
-                items.add(region.getDescription() + " " + region.getName(), region.getName());
+        public FormValidation doCheckRegion(@QueryParameter final String value) {
+            if (value == null || value.isEmpty()) {
+                return FormValidation.error("Please enter AWS Region");
             }
 
-            return items;
+            if (value.length() > Validation.MAX_REGION_LENGTH) {
+                return FormValidation.error(
+                        String.format(
+                                "The AWS Region name is too long, the name should be at most %d characters, you entered %d characters",
+                                Validation.MAX_REGION_LENGTH,
+                                value.length()));
+            }
+
+            if (value.trim().length() != value.length()) {
+                return FormValidation.error("Please remove leading and trailing whitespaces from AWS Region");
+            }
+
+            return FormValidation.ok();
         }
 
         public ListBoxModel doFillCategoryItems() {

--- a/src/main/java/com/amazonaws/codepipeline/jenkinsplugin/Validation.java
+++ b/src/main/java/com/amazonaws/codepipeline/jenkinsplugin/Validation.java
@@ -25,6 +25,7 @@ public class Validation {
     private static final String  LINE_SEPARATOR = System.lineSeparator();
 
     // These come from AWS CodePipeline specifications
+    public static final int MAX_REGION_LENGTH = 50; // https://docs.aws.amazon.com/accounts/latest/reference/API_Region.html
     public static final int MAX_VERSION_LENGTH = 9;
     public static final int MAX_PROVIDER_LENGTH = 25;
     public static final int MAX_PROJECT_NAME_LENGTH = 50;

--- a/src/main/resources/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM/config.jelly
+++ b/src/main/resources/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM/config.jelly
@@ -8,7 +8,7 @@
     </f:entry>
 
     <f:entry title="AWS Region" field="region">
-        <f:select name="region"/>
+        <f:textbox name="region"/>
     </f:entry>
 
     <f:entry title="Proxy Host" field="proxyHost">

--- a/src/main/resources/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM/help-awsAccessKey.html
+++ b/src/main/resources/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM/help-awsAccessKey.html
@@ -3,6 +3,5 @@
     If you installed Jenkins on a supported Amazon EC2 instance type, such as Amazon Linux, you can install the AWS CLI and configure a profile with the required credentials.
     This is the preferred method. In all other cases, you can store AWS credentials in these fields.
     You should securely configure your Jenkins instance to use HTTPS so that these credentials are not sent unencrypted.
-    For more information, see <a href=” aws.amazon.com/codepipeline/latest/userguide/concepts.html#concepts-pipeline-integration-other”>AWS CodePipeline Integration for Other Products and Services</a>.
   </p>
 </div>

--- a/src/main/resources/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM/help-awsSecretKey.html
+++ b/src/main/resources/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM/help-awsSecretKey.html
@@ -3,6 +3,5 @@
     If you installed Jenkins on a supported Amazon EC2 instance type, such as Amazon Linux, you can install the AWS CLI and configure a profile with the required credentials.
     This is the preferred method. In all other cases, you can store AWS credentials in these fields.
     You should securely configure your Jenkins instance to use HTTPS so that these credentials are not sent unencrypted.
-    For more information, see <a href=” aws.amazon.com/codepipeline/latest/userguide/concepts.html#concepts-pipeline-integration-other”>AWS CodePipeline Integration for Other Products and Services</a>.
   </p>
 </div>

--- a/src/main/resources/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM/help-category.html
+++ b/src/main/resources/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM/help-category.html
@@ -1,3 +1,3 @@
 <div>
-  <p>This is the category of the action type in AWS CodePipeline, and is usually either Build or Test. To see an example usage, see <a href=”http://docs.aws.amazon.com/codepipeline/latest/userguide/ getting-started-4.html#getting-started-4-prereqs-jenkins”>Install and Configure the AWS CodePipeline Plugin for Jenkins</a>.</p>
+  <p>This is the category of the action type in AWS CodePipeline, and is usually either Build or Test. To see an example usage, see <a href=https://docs.aws.amazon.com/codepipeline/latest/userguide/tutorials-four-stage-pipeline.html>Install and Configure the AWS CodePipeline Plugin for Jenkins</a>.</p>
 </div>

--- a/src/main/resources/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM/help-codepipelineActionType.html
+++ b/src/main/resources/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM/help-codepipelineActionType.html
@@ -1,3 +1,3 @@
 <div>
-  <p>These fields correspond to the information you must provide when adding Jenkins integration to a pipeline in AWS CodePipeline. For an example implementation, see <a href=”http://docs.aws.amazon.com/codepipeline/latest/userguide/ getting-started-4.html#getting-started-4-prereqs-jenkins”>Install and Configure the AWS CodePipeline Plugin for Jenkins</a>.</p>
+  <p>These fields correspond to the information you must provide when adding Jenkins integration to a pipeline in AWS CodePipeline. For an example implementation, see <a href=https://docs.aws.amazon.com/codepipeline/latest/userguide/tutorials-four-stage-pipeline.html>Install and Configure the AWS CodePipeline Plugin for Jenkins</a>.</p>
 </div>

--- a/src/main/resources/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM/help-iamRoleArn.html
+++ b/src/main/resources/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM/help-iamRoleArn.html
@@ -5,8 +5,8 @@
   </p>
 
   <ol>
-    <li>Log into the AWS Management Console, and navigate to the <a href="https://console.aws.amazon.com/iam/">Identity and Access Management console</a>.</li>
-    <li>Click on <a href="https://console.aws.amazon.com/iam/#roles">Roles</a>,  then click <strong>Create New Role</strong>.</li>
+    <li>Log into the AWS Management Console, and navigate to the <a href=https://console.aws.amazon.com/iam/>Identity and Access Management console</a>.</li>
+    <li>Click on <a href=https://console.aws.amazon.com/iam/#roles>Roles</a>,  then click <strong>Create New Role</strong>.</li>
     <li>Give an appropriate name for this role (for example, "JenkinsCodePipelineProject").</li>
     <li>In the "Select Role Type" screen, click "Role for Cross-Account Access" then select <strong>Allows IAM users from a 3rd party AWS account to access this account.</strong></li>
     <li>The account and external IDs for this Jenkins project are listed below</li>

--- a/src/main/resources/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM/help-provider.html
+++ b/src/main/resources/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM/help-provider.html
@@ -1,3 +1,3 @@
 <div>
-  <p>This is the provider name of the action type in AWS CodePipeline. You must provide this exact string when adding an action for Jenkins in AWS CodePipeline. To see an example usage, see <a href=”http://docs.aws.amazon.com/codepipeline/latest/userguide/ getting-started-4.html#getting-started-4-prereqs-jenkins”>Install and Configure the AWS CodePipeline Plugin for Jenkins</a>.</p>
+  <p>This is the provider name of the action type in AWS CodePipeline. You must provide this exact string when adding an action for Jenkins in AWS CodePipeline. To see an example usage, see <a href=https://docs.aws.amazon.com/codepipeline/latest/userguide/tutorials-four-stage-pipeline.html>Install and Configure the AWS CodePipeline Plugin for Jenkins</a>.</p>
 </div>

--- a/src/main/resources/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM/help-region.html
+++ b/src/main/resources/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM/help-region.html
@@ -1,0 +1,7 @@
+<div>
+  <p>The AWS region must be the same to the region where your action runs in CodePipeline. Examples: "us-east-1", "cn-north-1", "us-gov-west-1".
+    To list all supported regions, see <a href=”https://docs.aws.amazon.com/general/latest/gr/codepipeline.html”>AWS CodePipeline endpoints and quotas</a>.</p>
+</div>
+
+
+

--- a/src/main/resources/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM/help-region.html
+++ b/src/main/resources/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM/help-region.html
@@ -1,6 +1,6 @@
 <div>
   <p>The AWS region must be the same to the region where your action runs in CodePipeline. Examples: "us-east-1", "cn-north-1", "us-gov-west-1".
-    To list all supported regions, see <a href=”https://docs.aws.amazon.com/general/latest/gr/codepipeline.html”>AWS CodePipeline endpoints and quotas</a>.</p>
+    To list all supported regions, see <a href=https://docs.aws.amazon.com/general/latest/gr/codepipeline.html>AWS CodePipeline endpoints and quotas</a>.</p>
 </div>
 
 

--- a/src/test/java/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCMTest.java
+++ b/src/test/java/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCMTest.java
@@ -345,6 +345,27 @@ public class AWSCodePipelineSCMTest extends Suite {
         }
 
         @Test
+        public void doCheckRegionSucceedsWithValidRegion() {
+            assertEquals(FormValidation.ok(), descriptor.doCheckCategory(REGION));
+        }
+
+        @Test
+        public void doCheckRegionFailsIfRegionNotProvided() {
+            assertValidationMessage(
+                    FormValidation.error("Please enter AWS Region"),
+                    descriptor.doCheckRegion("")
+            );
+        }
+
+        @Test
+        public void doCheckRegionFailsIfRegionContainsATrailingWhitespace() {
+            assertValidationMessage(
+                    FormValidation.error("Please remove leading and trailing whitespaces from AWS Region"),
+                    descriptor.doCheckRegion(REGION + " ")
+            );
+        }
+
+        @Test
         public void doCheckCategorySucceedsWithBuildCategory() {
             assertEquals(FormValidation.ok(), descriptor.doCheckCategory(CategoryType.Build.name()));
         }


### PR DESCRIPTION
*Description of changes:*

Migrating select to textbox so now it accepts plaintext for AWS Region.
Given that, customers will avoid updating the plugin after CodePipeline is available in new regions.

Also, this change fixes broken link in existing help icons of the plugin.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
